### PR TITLE
Add hcloud tests

### DIFF
--- a/kafka-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/kafka-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: kafka-operator-integration-tests
+  description: "Cluster for Kafka Operator Integration Tests (Hetzner / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  wireguard: false
+  versions:
+    stackable-kafka-operator: "$KAFKA_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3
+    testdriver:
+      numberOfNodes: 1
+      agent: false
+services:
+  zookeeper: |
+    apiVersion: zookeeper.stackable.tech/v1alpha1
+    kind: ZookeeperCluster
+    metadata:
+      name: simple
+    spec:
+      version: 3.5.8
+      servers:
+        roleGroups:
+          default:
+            selector:
+              matchLabels:
+                kubernetes.io/arch: stackable-linux
+            config:
+              adminPort: 12000
+              metricsPort: 9505

--- a/kafka-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/kafka-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,13 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd integration-tests/ && cargo test --package kafka-operator-integration-tests -- --test-threads=1'
+exit_code=$?
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-1-stackable-agent.log
+/stackable.sh main-2 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-2-stackable-agent.log
+/stackable.sh main-3 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-3-stackable-agent.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-kafka-operator' > /target/stackable-kafka-operator.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-zookeeper-operator' > /target/stackable-zookeeper-operator.log
+exit $exit_code

--- a/monitoring-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/monitoring-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: monitoring-operator-integration-tests
+  description: "Cluster for Monitoring Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  wireguard: false
+  versions:
+    stackable-monitoring-operator: "$MONITORING_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 2
+    testdriver:
+      numberOfNodes: 1
+      agent: false

--- a/monitoring-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/monitoring-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,11 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd integration-tests/ && cargo test --package monitoring-operator-integration-tests -- --test-threads=1'
+exit_code=$?
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-1-stackable-agent.log
+/stackable.sh main-2 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-2-stackable-agent.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-monitoring-operator' > /target/stackable-monitoring-operator.log
+exit $exit_code

--- a/nifi-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/nifi-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: nifi-operator-integration-tests
+  description: "Cluster for NiFi Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  wireguard: false
+  versions:
+    stackable-nifi-operator: "$NIFI_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3
+    testdriver:
+      numberOfNodes: 1
+      agent: false
+services:
+  zookeeper: |
+    apiVersion: zookeeper.stackable.tech/v1alpha1
+    kind: ZookeeperCluster
+    metadata:
+      name: simple
+    spec:
+      version: 3.5.8
+      servers:
+        roleGroups:
+          default:
+            selector:
+              matchLabels:
+                kubernetes.io/arch: stackable-linux
+            config:
+              adminPort: 12000
+              metricsPort: 9505

--- a/nifi-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/nifi-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,13 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd integration-tests/ && cargo test --package nifi-operator-integration-tests -- --test-threads=1'
+exit_code=$?
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-1-stackable-agent.log
+/stackable.sh main-2 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-2-stackable-agent.log
+/stackable.sh main-3 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-3-stackable-agent.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-nifi-operator' > /target/stackable-nifi-operator.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-zookeeper-operator' > /target/stackable-zookeeper-operator.log
+exit $exit_code

--- a/opa-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/opa-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: opa-operator-integration-tests
+  description: "Cluster for Opa Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  wireguard: false
+  versions:
+    stackable-opa-operator: "$OPA_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3
+    testdriver:
+      numberOfNodes: 1
+      agent: false

--- a/opa-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/opa-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,12 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd integration-tests/ && cargo test --package opa-operator-integration-tests -- --test-threads=1'
+exit_code=$?
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-1-stackable-agent.log
+/stackable.sh main-2 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-2-stackable-agent.log
+/stackable.sh main-3 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-3-stackable-agent.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-opa-operator' > /target/stackable-opa-operator.log
+exit $exit_code

--- a/spark-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/spark-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: spark-operator-integration-tests
+  description: "Cluster for Spark Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  wireguard: false
+  versions:
+    stackable-spark-operator: "$SPARK_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3
+    testdriver:
+      numberOfNodes: 1
+      agent: false

--- a/spark-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/spark-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,12 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd integration-tests/ && cargo test --package spark-operator-integration-tests -- --test-threads=1'
+exit_code=$?
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-1-stackable-agent.log
+/stackable.sh main-2 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-2-stackable-agent.log
+/stackable.sh main-3 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-3-stackable-agent.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-spark-operator' > /target/stackable-spark-operator.log
+exit $exit_code

--- a/zookeeper-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/zookeeper-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: zookeper-operator-integration-tests
+  description: "Cluster for Zookeeper Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  wireguard: false
+  versions:
+    stackable-zookeeper-operator: "$ZOOKEEPER_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3
+    testdriver:
+      numberOfNodes: 1
+      agent: false

--- a/zookeeper-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/zookeeper-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,12 @@
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo sh -c "echo \"13.32.25.75     static.rust-lang.org\" >> /etc/hosts"'
+/stackable.sh testdriver-1 -i /.cluster/key 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
+/stackable.sh testdriver-1 -i /.cluster/key 'cargo --version'
+/stackable.sh testdriver-1 -i /.cluster/key 'sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git -y'
+/stackable.sh testdriver-1 -i /.cluster/key "git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git"
+/stackable.sh testdriver-1 -i /.cluster/key 'cd integration-tests/ && cargo test --package zookeeper-operator-integration-tests -- --test-threads=1'
+exit_code=$?
+/stackable.sh main-1 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-1-stackable-agent.log
+/stackable.sh main-2 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-2-stackable-agent.log
+/stackable.sh main-3 -i /.cluster/key 'journalctl -u stackable-agent' > /target/main-3-stackable-agent.log
+/stackable.sh orchestrator -i /.cluster/key 'journalctl -u stackable-zookeeper-operator' > /target/stackable-zookeeper-operator.log
+exit $exit_code


### PR DESCRIPTION
## Description
I added profiles for the new Hetzner (HCloud) clusters that T2 can build.

They were successfully tested in manually started test runs:
- https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Kafka%20Operator%20Integration%20Tests%20(flex)/8/
- https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Monitoring%20Operator%20Integration%20Tests%20(flex)/14/
- https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/NiFi%20Operator%20Integration%20Tests%20(flex)/8/
- https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/OPA%20Operator%20Integration%20Tests%20(flex)/7/
- https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Spark%20Operator%20Integration%20Tests%20(flex)/6/
- https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Zookeeper%20Operator%20Integration%20Tests%20(flex)/13/

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)