### PR TITLE
Use secret type Opaque for Superset credentials

### DIFF
--- a/superset-operator/tests/common/superset.rs
+++ b/superset-operator/tests/common/superset.rs
@@ -37,7 +37,7 @@ pub fn build_superset_credentials(
             kind: Secret
             metadata:
               name: {secret_name}
-            type: superset.stackable.tech/superset-credentials
+            type: Opaque
             stringData:
               adminUser.username: {admin_username}
               adminUser.firstname: Superset


### PR DESCRIPTION
## Description

The custom secret type for Superset credentials is not used and can be replaced with the built-in type `Opaque`.

## Review Checklist
- [x] Code contains useful comments