### PR TITLE
CI: pinned Hive in Trino operator test

### DIFF
--- a/trino-operator/.ci/integration-tests/ionos-centos-8/cluster.yaml
+++ b/trino-operator/.ci/integration-tests/ionos-centos-8/cluster.yaml
@@ -11,7 +11,7 @@ spec:
   wireguard: false
   region: de/fra
   versions:
-    hive-operator: 0.3.0-nightly
+    hive-operator: 0.3.0
     trino-operator: "$TRINO_OPERATOR_VERSION"
   nodes:
     worker:

--- a/trino-operator/create_test_cluster.fish
+++ b/trino-operator/create_test_cluster.fish
@@ -4,7 +4,7 @@
 # at the time of writing) seem to be affected by
 # https://github.com/minio/operator/issues/904
 set minioOperatorChartVersion 4.2.3
-set hiveOperatorVersion 0.3.0-nightly
+set hiveOperatorVersion 0.3.0
 set trinoOperatorVersion 0.1.0-nightly
 
 # Create Kubernetes cluster

--- a/trino-operator/create_test_cluster.fish
+++ b/trino-operator/create_test_cluster.fish
@@ -5,7 +5,6 @@
 # https://github.com/minio/operator/issues/904
 set minioOperatorChartVersion 4.2.3
 set hiveOperatorVersion 0.3.0
-set trinoOperatorVersion 0.1.0-nightly
 
 # Create Kubernetes cluster
 echo "
@@ -75,7 +74,8 @@ set -Ux S3_SECRET_KEY \
         --output=jsonpath="{.data.secretkey}" | base64 --decode)
 
 # Deploy Hive and Trino operators
-helm repo add stackable https://repo.stackable.tech/repository/helm-dev
-helm repo update stackable
-helm install hive-operator stackable/hive-operator --version=$hiveOperatorVersion
-helm install trino-operator stackable/trino-operator --version=$trinoOperatorVersion
+helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev
+helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable
+helm repo update
+helm install hive-operator stackable-stable/hive-operator --version=$hiveOperatorVersion
+helm install trino-operator stackable-dev/trino-operator --devel


### PR DESCRIPTION
## Description
Now that we finally have a released Version of Hive, we can pin its version in the Trino test.
The following run was successful w/ Hive Operator 0.3.0: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Trino%20Operator%20Integration%20Tests%20(flex)/7/
The second commit changes the test run in Kind to use the latest development version of Trino. It was NOT tested with a Kind cluster.

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)