### PR TITLE
fixed badges on README files

### DIFF
--- a/druid-operator/README.md
+++ b/druid-operator/README.md
@@ -1,5 +1,7 @@
 # Druid Operator Tests
 
+[![Build Actions Status](https://ci.stackable.tech/job/Druid%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Druid%20Operator%20Integration%20Tests)
+
 This package contains tests for the Apache Druid operator.
 
 ## Requirements

--- a/hive-operator/README.md
+++ b/hive-operator/README.md
@@ -1,5 +1,7 @@
 # hive-operator-integration-tests
 
+[![Build Actions Status](https://ci.stackable.tech/job/Hive%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Hive%20Operator%20Integration%20Tests)
+
 In order to test hive we need the `hive-metastore-client` and `thrift` python library.
 
 ## Installation

--- a/monitoring-operator/README.md
+++ b/monitoring-operator/README.md
@@ -1,7 +1,5 @@
 # monitoring-operator-integration-tests
 
-[![Build Actions Status](https://ci.stackable.tech/job/Monitoring%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Monitoring%20Operator%20Integration%20Tests)
-
 This repository bundles integration tests for the [Stackable Operator](https://github.com/stackabletech/monitoring-operator) for Monitoring and Metrics. 
 
 ## Requirements

--- a/superset-operator/README.md
+++ b/superset-operator/README.md
@@ -1,7 +1,5 @@
 # superset-operator-integration-tests
 
-[![Build Actions Status](https://github.com/stackabletech/superset-operator-integration-tests/workflows/Rust/badge.svg)](https://github.com/stackabletech/superset-operator-integration-tests/actions)
-[![Build Actions Status](https://github.com/stackabletech/superset-operator-integration-tests/workflows/Security%20audit/badge.svg)](https://github.com/stackabletech/superset-operator-integration-tests/actions)
 [![Build Actions Status](https://ci.stackable.tech/job/Superset%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Superset%20Operator%20Integration%20Tests)
 
 This repository bundles integration tests for the [Stackable Operator](https://github.com/stackabletech/superset-operator) for Apache Superset.

--- a/trino-operator/README.md
+++ b/trino-operator/README.md
@@ -1,0 +1,5 @@
+# trino-operator-integration-tests
+
+[![Build Actions Status](https://ci.stackable.tech/job/Trino%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Trino%20Operator%20Integration%20Tests)
+
+

--- a/zookeeper-operator/README.md
+++ b/zookeeper-operator/README.md
@@ -1,7 +1,5 @@
 # zookeeper-operator-integration-tests
 
-[![Build Actions Status](https://github.com/stackabletech/zookeeper-operator-integration-tests/workflows/Rust/badge.svg)](https://github.com/stackabletech/zookeeper-operator-integration-tests/actions)
-[![Build Actions Status](https://github.com/stackabletech/zookeeper-operator-integration-tests/workflows/Security%20audit/badge.svg)](https://github.com/stackabletech/zookeeper-operator-integration-tests/actions)
 [![Build Actions Status](https://ci.stackable.tech/job/Zookeeper%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Zookeeper%20Operator%20Integration%20Tests)
 
 This repository bundles integration tests for the [Stackable Operator](https://github.com/stackabletech/zookeeper-operator) for Apache ZooKeeper.


### PR DESCRIPTION
## Description
During the transition to the single repo and K8s, some badges were left behind. This PR fixes the badges.

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)