### PR TITLE
Change the druid nodeport

### DIFF
--- a/druid-operator/tests/common/druid.rs
+++ b/druid-operator/tests/common/druid.rs
@@ -60,7 +60,7 @@ pub fn build_druid_cluster(
                   matchLabels:
                     kubernetes.io/os: linux
                 config:
-                  plaintextPort: 8081
+                  plaintextPort: 8084
                   metricsPort: 9090
                 replicas: {replicas}
           historicals:

--- a/druid-operator/tests/create_cluster.rs
+++ b/druid-operator/tests/create_cluster.rs
@@ -37,7 +37,7 @@ fn test_create_1_cluster_0_22_0() -> Result<()> {
     );
 
     // for each process/pod, create a NodePort service and check the health status
-    let s1 = TestService::new(&cluster.client, "druid", "coordinator", 8081, 30081);
+    let s1 = TestService::new(&cluster.client, "druid", "coordinator", 8084, 30081);
     let s2 = TestService::new(&cluster.client, "druid", "broker", 8082, 30082);
     let s3 = TestService::new(&cluster.client, "druid", "historical", 8083, 30083);
     let s4 = TestService::new(&cluster.client, "druid", "middleManager", 8091, 30091);

--- a/spark-operator/tests/common/spark.rs
+++ b/spark-operator/tests/common/spark.rs
@@ -44,6 +44,8 @@ pub fn build_spark_custom_resource(
                   matchLabels:
                     kubernetes.io/os: linux
                 replicas: {}
+                config:
+                  masterWebUiPort: 8082
           workers:
             roleGroups:
               default:
@@ -51,6 +53,8 @@ pub fn build_spark_custom_resource(
                   matchLabels:
                     kubernetes.io/os: linux
                 replicas: {}
+                config:
+                  masterWebUiPort: 8083
           historyServers:
             roleGroups:
               default:

--- a/spark-operator/tests/common/spark.rs
+++ b/spark-operator/tests/common/spark.rs
@@ -54,7 +54,7 @@ pub fn build_spark_custom_resource(
                     kubernetes.io/os: linux
                 replicas: {}
                 config:
-                  masterWebUiPort: 8083
+                  workerWebUiPort: 8083
           historyServers:
             roleGroups:
               default:

--- a/spark-operator/tests/restart_cluster.rs
+++ b/spark-operator/tests/restart_cluster.rs
@@ -14,7 +14,7 @@ fn test_restart_command() -> Result<()> {
     let command_name = "spark-restart-command";
     let command_kind = "Restart";
     let version = SparkVersion::v3_0_1;
-    let http_port: i32 = 8080;
+    let http_port: i32 = 8082;
 
     let mut cluster = build_test_cluster();
 

--- a/trino-operator/tests/common/trino.rs
+++ b/trino-operator/tests/common/trino.rs
@@ -106,7 +106,7 @@ pub fn build_trino_cluster(
             config: Some(CommonConfiguration {
                 config: Some(TrinoConfig {
                     coordinator: None,
-                    http_server_http_port: Some(8081),
+                    http_server_http_port: Some(8082),
                     http_server_https_port: None,
                     query_max_memory: None,
                     query_max_memory_per_node: None,


### PR DESCRIPTION
In our clusters the nodeport 8081 is already used by a daemonset

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)