### PR TITLE
reactivated Zookeeper Operator integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ members = [
     "spark-operator",
     "superset-operator",
     # "trino-operator",
-    # "zookeeper-operator"
+    "zookeeper-operator"
 ]


### PR DESCRIPTION
## Description
During the activation of the Druid Operator integration test, we accidentally deactivated the ZooKeeper test, which is fixed by this PR

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)