### PR TITLE
Airflow in Jenkins CI

### DIFF
--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/cluster.yaml
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/cluster.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: ionos-centos-8
+metadata: 
+  name: airflow-ionos-centos-8
+  description: "Cluster for Airflow Operator Integration Tests (IONOS / CentOS 8)"
+domain: stackable.demo
+publicKeys: []
+spec:
+  wireguard: false
+  region: de/fra
+  k8sVersion: "$K8S_VERSION"
+  versions:
+    airflow-operator: "$AIRFLOW_OPERATOR_VERSION"
+  nodes:
+    worker:
+      numberOfNodes: 3
+      numberOfCores: 2
+      memoryMb: 8192
+      diskType: HDD 
+      diskSizeGb: 100
+    testdriver:
+      numberOfNodes: 1
+      numberOfCores: 2
+      memoryMb: 8192
+      diskType: HDD 
+      diskSizeGb: 100
+      k8s_node: false

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -31,7 +31,7 @@ ssh testdriver-1 ./set-up-redis.sh
 
 # Wait for Redis to be up and running
 echo Starting Redis ...
-while [ "$(kubectl get pod airflow-redis-redis-master-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
+while [ "$(kubectl get pod airflow-redis-replicas-2 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
 	sleep 2
 done
 echo Redis started.

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -31,8 +31,9 @@ ssh testdriver-1 ./set-up-redis.sh
 
 # Wait for Redis to be up and running
 echo Starting Redis ...
-while [ "$(kubectl get pod airflow-redis-replicas-2 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
-	sleep 2
+while [ "$(kubectl get statefulset airflow-redis-master --output=jsonpath='{.status.readyReplicas}')" != "1" ] || 
+      [ "$(kubectl get statefulset airflow-redis-replicas --output=jsonpath='{.status.readyReplicas}')" != "3" ]; do
+    sleep 2
 done
 echo Redis started.
 echo

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -1,0 +1,61 @@
+# Write script to set up Postgres and execute it on testdriver-1
+echo "helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update bitnami
+helm install airflow-postresql bitnami/postgresql \
+    --set postgresqlUsername=airflow \
+    --set postgresqlPassword=airflow \
+    --set postgresqlDatabase=airflow
+" > set-up-postgres.sh
+scp set-up-postgres.sh testdriver-1:set-up-postgres.sh
+ssh testdriver-1 chmod a+x set-up-postgres.sh
+ssh testdriver-1 ./set-up-postgres.sh
+
+# Wait for Postgres to be up and running
+echo Starting Postgresql database ...
+while [ "$(kubectl get pod airflow-postgresql-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
+	sleep 2
+done
+echo Postgresql database started.
+echo
+
+
+# Write script to set up Redis and execute it on testdriver-1
+echo "helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update bitnami
+helm install airflow-redis bitnami/redis \
+    --set auth.password=redis
+" > set-up-redis.sh
+scp set-up-redis.sh testdriver-1:set-up-redis.sh
+ssh testdriver-1 chmod a+x set-up-redis.sh
+ssh testdriver-1 ./set-up-redis.sh
+
+# Wait for Redis to be up and running
+echo Starting Redis ...
+while [ "$(kubectl get pod airflow-redis-redis-master-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
+	sleep 2
+done
+echo Redis started.
+echo
+
+# install stuff on testdriver
+ssh testdriver-1 sudo yum install vim procps curl gcc make pkgconfig openssl-devel systemd-devel python3-pip container-selinux selinux-policy-base git --nobest -y
+
+# install Rust with a script on testdriver
+echo "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y" > install-rust.sh
+scp install-rust.sh testdriver-1:install-rust.sh
+ssh testdriver-1 chmod a+x install-rust.sh
+ssh testdriver-1 ./install-rust.sh
+
+# clone integration test repository on testdriver
+ssh testdriver-1 git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git
+
+# create script which runs the test and execute it
+echo "cd integration-tests/airflow-operator
+cargo test -- --nocapture
+" > run-test.sh
+scp run-test.sh testdriver-1:run-test.sh
+ssh testdriver-1 chmod a+x run-test.sh
+ssh testdriver-1 ./run-test.sh
+exit_code=$?
+./operator-logs.sh airflow > /target/airflow-operator.log
+exit $exit_code

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -1,7 +1,7 @@
 # Write script to set up Postgres and execute it on testdriver-1
 echo "helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update bitnami
-helm install airflow-postresql bitnami/postgresql \
+helm install airflow-postgresql bitnami/postgresql \
     --set postgresqlUsername=airflow \
     --set postgresqlPassword=airflow \
     --set postgresqlDatabase=airflow

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -12,7 +12,7 @@ ssh testdriver-1 ./set-up-postgres.sh
 
 # Wait for Postgres to be up and running
 echo Starting Postgresql database ...
-while [ "$(kubectl get pod airflow-postgresql-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
+while [ "$(kubectl get pod airflow-postgresql-postgresql-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
 	sleep 2
 done
 echo Postgresql database started.


### PR DESCRIPTION
## Description
Added the files necessary to execute the Airflow integration tests in Jenkins CI.
A test run was executed on this branch, you find the results here: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Airflow%20Operator%20Integration%20Tests%20(flex)/5/

After this PR is merged, we can add a nightly Job for Airflow running on `main` branch against the latest nightly binary. 

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)