### PR TITLE
HDFS Tests in CI/Jenkins

### DIFF
--- a/hdfs-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/hdfs-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: hdfs-operator-integration-tests
+  description: "Cluster for HDFS Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  k8sVersion: "$K8S_VERSION"
+  wireguard: false
+  versions:
+    hdfs-operator: "$HDFS_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3

--- a/hdfs-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/hdfs-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,6 +1,5 @@
 git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git
-cd integration-tests/hdfs-operator
-kubectl kuttl test
+(cd integration-tests/hdfs-operator && kubectl kuttl test)
 exit_code=$?
 ./operator-logs.sh hdfs > /target/hdfs-operator.log
 exit $exit_code

--- a/hdfs-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/hdfs-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,6 @@
+git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git
+cd integration-tests/hdfs-operator
+kubectl kuttl test
+exit_code=$?
+./operator-logs.sh hdfs > /target/hdfs-operator.log
+exit $exit_code


### PR DESCRIPTION
## Description
This adds a CI/Jenkins test running on Hetzner CentOS8 using `kuttl`.
Please see successful test run here: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/HDFS%20Operator%20Integration%20Tests%20(flex)/4/

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)