### PR TITLE
Fix Superset integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.13"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
  "atty",
  "bitflags",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.12"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -702,7 +702,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "spectral",
- "stackable-operator",
+ "stackable-operator 0.8.0",
  "strum",
  "strum_macros",
  "tokio",
@@ -895,9 +895,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "linked-hash-map"
@@ -1660,12 +1660,12 @@ dependencies = [
 
 [[package]]
 name = "stackable-airflow-crd"
-version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/airflow-operator.git?branch=main#a40239cb7f8d9732f30f0e3e97f119d82166bbd4"
+version = "0.2.0-nightly"
+source = "git+https://github.com/stackabletech/airflow-operator.git?branch=main#b972ccc1e8a752c0a2a0914ff6ffd84f22189a62"
 dependencies = [
  "serde",
  "serde_json",
- "stackable-operator",
+ "stackable-operator 0.8.0",
  "strum",
  "strum_macros",
 ]
@@ -1705,14 +1705,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "stackable-zookeeper-crd"
-version = "0.9.0-nightly"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#5d90be82608ada871421add2d4adc66e3db33635"
+name = "stackable-operator"
+version = "0.9.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.9.0#e7c3e2a10c7dd6469c1fdf2fc570e962ea776762"
+dependencies = [
+ "async-trait",
+ "backoff",
+ "chrono",
+ "clap",
+ "const_format",
+ "derivative",
+ "either",
+ "futures",
+ "json-patch",
+ "k8s-openapi",
+ "kube",
+ "lazy_static",
+ "product-config",
+ "rand 0.8.4",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "stackable-superset-crd"
+version = "0.3.0-nightly"
+source = "git+https://github.com/stackabletech/superset-operator.git?branch=main#02a4d1ac456b44f95580eb9f7c18cfca6f4ca2f1"
 dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "stackable-operator",
+ "stackable-operator 0.9.0",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
+name = "stackable-zookeeper-crd"
+version = "0.9.0-nightly"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#86e874f19f95c1f43ef25ab0a8f012d921aa4166"
+dependencies = [
+ "serde",
+ "serde_json",
+ "snafu",
+ "stackable-operator 0.8.0",
  "strum",
 ]
 
@@ -1742,6 +1789,18 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "superset-operator-integration-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "indoc",
+ "integration-test-commons",
+ "reqwest",
+ "serde_yaml",
+ "stackable-superset-crd",
 ]
 
 [[package]]
@@ -1954,9 +2013,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if",
  "log",
@@ -1967,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1978,11 +2037,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -2092,6 +2152,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ members = [
     #"kafka-operator",
     # "monitoring-operator",
     # "nifi-operator",
-    #"superset-operator",
+    "superset-operator",
     "zookeeper-operator"
 ]

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -2,9 +2,10 @@
 echo "helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update bitnami
 helm install airflow-postgresql bitnami/postgresql \
-    --set postgresqlUsername=airflow \
-    --set postgresqlPassword=airflow \
-    --set postgresqlDatabase=airflow
+    --version 11.0.0 \
+    --set auth.username=airflow \
+    --set auth.password=airflow \
+    --set auth.database=airflow
 " > set-up-postgres.sh
 scp set-up-postgres.sh testdriver-1:set-up-postgres.sh
 ssh testdriver-1 chmod a+x set-up-postgres.sh

--- a/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -13,7 +13,7 @@ ssh testdriver-1 ./set-up-postgres.sh
 
 # Wait for Postgres to be up and running
 echo Starting Postgresql database ...
-while [ "$(kubectl get pod airflow-postgresql-postgresql-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
+while [ "$(kubectl get pod airflow-postgresql-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
 	sleep 2
 done
 echo Postgresql database started.

--- a/create_test_cluster.py
+++ b/create_test_cluster.py
@@ -230,18 +230,20 @@ def install_dependencies_opa():
 def install_dependencies_superset():
   logging.info("Installing dependencies for Superset")
   args = [
-    '--set', 'postgresqlUsername=superset',
-    '--set', 'postgresqlPassword=superset',
-    '--set', 'postgresqlDatabase=superset'
+    '--version', '11.0.0',
+    '--set', 'auth.username=superset',
+    '--set', 'auth.password=superset',
+    '--set', 'auth.database=superset'
   ]
   helper_install_helm_release("superset-postgresql", "postgresql", "bitnami", "https://charts.bitnami.com/bitnami", args)
 
 def install_dependencies_airflow():
   logging.info("Installing dependencies for Airflow")
   args = [
-    '--set', 'postgresqlUsername=airflow',
-    '--set', 'postgresqlPassword=airflow',
-    '--set', 'postgresqlDatabase=airflow'
+    '--version', '11.0.0',
+    '--set', 'auth.username=airflow',
+    '--set', 'auth.password=airflow',
+    '--set', 'auth.database=airflow'
   ]
   helper_install_helm_release("airflow-postgresql", "postgresql", "bitnami", "https://charts.bitnami.com/bitnami", args)
 

--- a/superset-operator/.ci/integration-tests/ionos-centos-8/test.sh
+++ b/superset-operator/.ci/integration-tests/ionos-centos-8/test.sh
@@ -2,9 +2,10 @@
 echo "helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update bitnami
 helm install superset bitnami/postgresql \
-    --set postgresqlUsername=superset \
-    --set postgresqlPassword=superset \
-    --set postgresqlDatabase=superset
+    --version 11.0.0 \
+    --set auth.username=superset \
+    --set auth.password=superset \
+    --set auth.database=superset
 " > set-up-postgres.sh
 scp set-up-postgres.sh testdriver-1:set-up-postgres.sh
 ssh testdriver-1 chmod a+x set-up-postgres.sh

--- a/superset-operator/Cargo.toml
+++ b/superset-operator/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors = ["Siegfried Weber <mail@siegfriedweber.net>"]
+authors = ["Stackable GmbH <info@stackable.de>"]
 description = "Integration tests for the Stackable Operator for Apache Superset"
 edition = "2021"
 license = "OSL-3.0"
 name = "superset-operator-integration-tests"
-repository = "https://github.com/stackabletech/superset-operator-integration-tests"
+repository = "https://github.com/stackabletech/integration-tests"
 version = "0.1.0"
 
 [dependencies]

--- a/superset-operator/tests/create_cluster.rs
+++ b/superset-operator/tests/create_cluster.rs
@@ -3,13 +3,11 @@ pub mod common;
 use anyhow::Result;
 use common::{
     checks::custom_checks,
-    superset::{
-        build_command, build_superset_cluster, build_superset_credentials, build_test_cluster,
-    },
+    superset::{build_superset_cluster, build_superset_credentials, build_test_cluster},
 };
 use integration_test_commons::operator::service::create_node_port_service;
 use integration_test_commons::test::prelude::{Pod, Secret};
-use stackable_superset_crd::commands::Init;
+use stackable_superset_crd::supersetdb::{SupersetDB, SupersetDBStatusCondition};
 use std::collections::BTreeMap;
 
 #[test]
@@ -31,20 +29,14 @@ fn test_create_cluster_1_3_2() -> Result<()> {
     cluster.create_or_update(&superset_cr, &BTreeMap::new(), replicas)?;
     let created_pods = cluster.list::<Pod>(None);
 
-    let init: Init = build_command(
-        "superset-cluster-command-init",
-        "Init",
-        cluster.name(),
-        secret_name,
-    )?;
-    cluster.apply_command(&init)?;
+    let superset_db = cluster
+        .client
+        .find_namespaced::<SupersetDB>(cluster.name())
+        .expect("Resource SupersetDB expected");
 
-    cluster.client.verify_status(&init, |command| {
-        command
-            .status
-            .as_ref()
-            .and_then(|status| status.finished_at.as_ref())
-            .is_some()
+    cluster.client.verify_status(&superset_db, |superset_db| {
+        superset_db.status.as_ref().map(|status| status.condition)
+            == Some(SupersetDBStatusCondition::Ready)
     });
 
     let admin_service =


### PR DESCRIPTION
## Description

* Superset integration tests fixed and re-enabled
* Bitnami PostgreSQL Helm chart upgraded and pinned to version 11.0.0
* Fixed PostgreSQL installation in CI scripts of Superset and Airflow

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)