### PR TITLE
HDFS: Use 3.10-slim instead of bullseye.

### DIFF
--- a/hdfs-operator/README.md
+++ b/hdfs-operator/README.md
@@ -1,0 +1,13 @@
+# hdfs-operator-integration-tests
+
+[![Build Actions Status](https://ci.stackable.tech/job/HDFS%20Operator%20Integration%20Tests/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/HDFS%20Operator%20Integration%20Tests)
+
+This repository bundles integration tests for the [Stackable Operator](https://github.com/stackabletech/hdfs-operator) for Apache HDFS. 
+
+## Run tests
+
+The integration tests are based on [KUTTL](https://kuttl.dev).
+
+    ./create_test_cluster.py --kind kind --operator hdfs --debug
+    cd hdfs-operator
+    kubectl kuttl test

--- a/hdfs-operator/tests/kuttl/smoke/02-webhdfs.yaml
+++ b/hdfs-operator/tests/kuttl/smoke/02-webhdfs.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: webhdfs
-        image: python:3.10-bullseye
+        image: python:3.10-slim
         stdin: true
         tty: true


### PR DESCRIPTION
## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)