### PR TITLE
CI/Airflow: removed Postgresql and Redis

### DIFF
--- a/airflow-operator/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/airflow-operator/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,35 +1,3 @@
-# Bitnami Helm repo to install collaborators
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm repo update bitnami
-
-# Install Postgres
-helm install airflow-postgresql bitnami/postgresql \
-    --version 11.0.0 \
-    --set auth.username=airflow \
-    --set auth.password=airflow \
-    --set auth.database=airflow
-
-# Wait for Postgres to be up and running
-echo Starting Postgresql database ...
-while [ "$(kubectl get pod airflow-postgresql-0 --output=jsonpath='{.status.containerStatuses[0].ready}')" != "true" ]; do
-	sleep 2
-done
-echo Postgresql database started.
-echo
-
-# Install Redis
-helm install airflow-redis bitnami/redis \
-    --set auth.password=redis
-
-# Wait for Redis to be up and running
-echo Starting Redis ...
-while [ "$(kubectl get statefulset airflow-redis-master --output=jsonpath='{.status.readyReplicas}')" != "1" ] || 
-      [ "$(kubectl get statefulset airflow-redis-replicas --output=jsonpath='{.status.readyReplicas}')" != "3" ]; do
-    sleep 2
-done
-echo Redis started.
-echo
-
 # Execute tests
 git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git
 (cd integration-tests/airflow-operator && kubectl kuttl test)


### PR DESCRIPTION
As Postgresql and Redis are provisioned **within** the kuttl tests, it is no longer required to prepare them in the test script.
This test run proves it: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Airflow%20Operator%20Integration%20Tests%20(flex)/11/

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)