### PR TITLE
Adapt to new nifi discovery

### DIFF
--- a/nifi-operator/tests/kuttl/smoke/00-install-zk.yaml
+++ b/nifi-operator/tests/kuttl/smoke/00-install-zk.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: zookeeper.stackable.tech/v1alpha1
 kind: ZookeeperCluster
 metadata:
@@ -11,3 +12,11 @@ spec:
           myidOffset: 10
   version: 3.5.8
   stopped: false
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: test-nifi-znode
+spec:
+  clusterRef:
+    name: test-zk

--- a/nifi-operator/tests/kuttl/smoke/01-install-nifi.yaml
+++ b/nifi-operator/tests/kuttl/smoke/01-install-nifi.yaml
@@ -20,9 +20,7 @@ metadata:
   name: test-nifi
 spec:
   version: "1.15.0"
-  zookeeperReference:
-    name: test-zk
-    chroot: /nifiytest
+  zookeeperConfigMapName: test-nifi-znode
   authenticationConfig:
     method:
       SingleUser:
@@ -40,3 +38,4 @@ spec:
           log:
             rootLogLevel: INFO
         replicas: 2
+

--- a/nifi-operator/tests/kuttl/smoke/02-scale-up-nifi.yaml
+++ b/nifi-operator/tests/kuttl/smoke/02-scale-up-nifi.yaml
@@ -5,9 +5,7 @@ metadata:
   name: test-nifi
 spec:
   version: "1.15.0"
-  zookeeperReference:
-    name: test-zk
-    chroot: /nifiytest
+  zookeeperConfigMapName: test-nifi-znode
   authenticationConfig:
     method:
       SingleUser:

--- a/nifi-operator/tests/kuttl/smoke/05-enable-anonymous.yaml
+++ b/nifi-operator/tests/kuttl/smoke/05-enable-anonymous.yaml
@@ -5,9 +5,7 @@ metadata:
   name: test-nifi
 spec:
   version: "1.15.0"
-  zookeeperReference:
-    name: test-zk
-    chroot: /nifiytest
+  zookeeperConfigMapName: test-nifi-znode
   authenticationConfig:
     method:
       SingleUser:

--- a/trino-operator/tests/kuttl/smoke/02-install-check.yaml
+++ b/trino-operator/tests/kuttl/smoke/02-install-check.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: trino-test-helper
-          image: python:3.10-bullseye
+          image: python:3.10-slim
           stdin: true
           tty: true


### PR DESCRIPTION
## Description

- adapted cluster reference to configmap name
- use znode
- python image changed to slim

related to https://github.com/stackabletech/nifi-operator/pull/207

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)