### PR TITLE
Added prometheus to create_test_cluster.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If this happens please add a (any) repository to Helm manually (this can be dele
 To be more precise: Helm needs to find a valid `repositories.yaml` file in its config directory. 
 
     ./create_test_cluster.py --debug --kind --operator <operator>
+
 ## Set up a test kind-cluster
 
 The `create_test_cluster.py` utility script will set up a test kind cluster (if requested with the `--kind` parameter) and install dependencies required for running the integration tests.
@@ -45,6 +46,14 @@ Example
     ./create_test_cluster.py --kind --operator trino superset=0.3.0
 
 IMPORTANT: The script might ask you to set environment variables that are needed for the integration tests!
+
+## Set up a test kind-cluster with monitoring
+
+This will install the [Prometheus Operator](https://prometheus-operator.dev) and a general ServiceMonitor to scrape metrics as described [here](https://docs.stackable.tech/home/monitoring.html). 
+
+Example
+
+    ./create_test_cluster.py --debug --kind --prometheus --operator trino
 
 ## Run KUTTL tests
 

--- a/create_test_cluster.py
+++ b/create_test_cluster.py
@@ -98,7 +98,7 @@ def check_args() -> Namespace:
                            "Otherwise the provided name will be used",
                       )
   parser.add_argument('--debug', '-d', action='store_true', required=False, help="Will print additional debug statements (e.g. output from all run commands)")
-  parser.add_argument('--prometheus', '-prom', action='store_true', required=False, help="Will install the Prometheus operator for scraping metrics.")
+  parser.add_argument('--prometheus', '-m', action='store_true', required=False, help="Will install the Prometheus operator for scraping metrics.")
   args = parser.parse_args()
 
   log_level = 'DEBUG' if args.debug else 'INFO'

--- a/create_test_cluster.py
+++ b/create_test_cluster.py
@@ -21,6 +21,9 @@ HELM_TEST_REPO_NAME = "stackable-test"
 HELM_TEST_REPO_URL = "https://repo.stackable.tech/repository/helm-test"
 HELM_STABLE_REPO_NAME = "stackable"
 HELM_STABLE_REPO_URL = "https://repo.stackable.tech/repository/helm-stable"
+HELM_PROMETHEUS_REPO_NAME = "prometheus-community"
+HELM_PROMETHEUS_REPO_URL = "https://prometheus-community.github.io/helm-charts"
+HELM_PROMETHEUS_CHART_NAME = "kube-prometheus-stack"
 
 
 KIND_CLUSTER_DEFINITION = """
@@ -65,6 +68,22 @@ spec:
       targetPort: 9000
 """
 
+PROMETHEUS_SCRAPE_SERVICE = """
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scrape-label
+  labels:
+    release: prometheus-operator
+spec:
+  endpoints:
+  - port: metrics
+  jobLabel: app.kubernetes.io/instance
+  selector:
+    matchLabels:
+      prometheus.io/scrape: "true"
+"""
+
 
 def check_args() -> Namespace:
   parser = argparse.ArgumentParser(
@@ -79,6 +98,7 @@ def check_args() -> Namespace:
                            "Otherwise the provided name will be used",
                       )
   parser.add_argument('--debug', '-d', action='store_true', required=False, help="Will print additional debug statements (e.g. output from all run commands)")
+  parser.add_argument('--prometheus', '-prom', action='store_true', required=False, help="Will install the Prometheus operator for scraping metrics.")
   args = parser.parse_args()
 
   log_level = 'DEBUG' if args.debug else 'INFO'
@@ -141,6 +161,22 @@ def install_stackable_operator(name: str, version: str = None):
   else:
     args = ["--devel"]
     helper_install_helm_release(operator_name, operator_name, HELM_DEV_REPO_NAME, HELM_DEV_REPO_URL, args)
+
+
+def install_prometheus():
+  """This installs the Prometheus Operator in Helm
+
+  It makes sure that the proper repository is installed and deploys a generic ServiceMonitor service
+  """
+  helper_add_helm_repo(HELM_PROMETHEUS_REPO_NAME, HELM_PROMETHEUS_REPO_URL)
+  release = helper_find_helm_release(HELM_PROMETHEUS_REPO_NAME, HELM_PROMETHEUS_CHART_NAME)
+
+  if release:
+    logging.info(f"Prometheus Operator already running release with name [{release['name']}] and chart [{release['chart']}] - skipping installation")
+    return
+
+  helper_install_helm_release("prometheus-operator", HELM_PROMETHEUS_CHART_NAME, HELM_PROMETHEUS_REPO_NAME, HELM_PROMETHEUS_REPO_URL)
+  helper_execute(['kubectl', 'apply', '-f', '-'], PROMETHEUS_SCRAPE_SERVICE)
 
 
 def helper_check_docker_running():
@@ -319,7 +355,8 @@ def helper_install_helm_release(name: str, chart_name: str, repo_name: str = Non
   logging.debug(f"No Helm release with the name {name} found")
   logging.info(f"Installing Helm release [{name}] from chart [{chart_name}] now")
   args = ['helm', 'install', name, f"{repo_name}/{chart_name}"]
-  args = args + install_args
+  if install_args:
+    args = args + install_args
   helper_execute(args)
   logging.info("Helm release was installed successfully")
 
@@ -394,7 +431,9 @@ def main() -> int:
   if args.provision:
     helper_execute(['kubectl', 'apply', '-f', args.provision])
     logging.info(f"Successfully applied resources from [{args.provision}]")
-
+  # install prometheus
+  if args.prometheus:
+    install_prometheus()
   return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The flag `--prometheus` will install the prometheus operator stack and a general ServiceMonitor as described in https://docs.stackable.tech/home/monitoring.html

fixes https://github.com/stackabletech/integration-tests/issues/125

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)