### PR TITLE
Added namespaceSelector any to scrape all namespaces

### DIFF
--- a/create_test_cluster.py
+++ b/create_test_cluster.py
@@ -82,6 +82,8 @@ spec:
   selector:
     matchLabels:
       prometheus.io/scrape: "true"
+  namespaceSelector:
+    any: true      
 """
 
 


### PR DESCRIPTION
## Description

Prometheus was only scraping default namespace, which did not work with the random generated kuttl namespaces.

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)