### PR TITLE
hbase: tests against version 2.4.9

### DIFF
--- a/hbase-operator/tests/smoke/00-assert.yaml
+++ b/hbase-operator/tests/smoke/00-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-zk
-timeout: 300
+timeout: 600
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/hbase-operator/tests/smoke/01-assert.yaml
+++ b/hbase-operator/tests/smoke/01-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-hdfs
-timeout: 300
+timeout: 600
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/hbase-operator/tests/smoke/02-assert.yaml
+++ b/hbase-operator/tests/smoke/02-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-hbase
-timeout: 300
+timeout: 600
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/hbase-operator/tests/smoke/02-install-hbase.yaml
+++ b/hbase-operator/tests/smoke/02-install-hbase.yaml
@@ -3,7 +3,7 @@ kind: HbaseCluster
 metadata:
   name: test-hbase
 spec:
-  version: 2.4.6
+  version: 2.4.9
   config:
     hdfsConfigMapName: test-hdfs-namenode-default
     zookeeperConfigMapName: test-znode


### PR DESCRIPTION
## Description

- Updated tests to run against version 2.4.9 (and upped some timeouts)
- see [PR 133](https://github.com/stackabletech/hbase-operator/pull/133): no smoke-testable changes

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)