### PR TITLE
Bring back Kafka 2.8.1 tests using Kuttl templating

### DIFF
--- a/kafka-operator/kuttl-test.yaml
+++ b/kafka-operator/kuttl-test.yaml
@@ -4,3 +4,6 @@ testDirs:
 - ./tests/kuttl
 startKIND: false
 suppress: ["events"]
+variableSets:
+  - kafkaVersion: 3.1.0
+  - kafkaVersion: 2.8.1

--- a/kafka-operator/tests/kuttl/smoke/01-install-kafka.yaml
+++ b/kafka-operator/tests/kuttl/smoke/01-install-kafka.yaml
@@ -9,7 +9,7 @@ kind: KafkaCluster
 metadata:
   name: simple-kafka
 spec:
-  version: 3.1.0
+  version: {{ .Variables.kafkaVersion }}
   zookeeperConfigMapName: kafka-zk
   brokers:
     roleGroups:

--- a/kafka-operator/tests/kuttl/smoke/01-install-kafka.yaml
+++ b/kafka-operator/tests/kuttl/smoke/01-install-kafka.yaml
@@ -9,7 +9,7 @@ kind: KafkaCluster
 metadata:
   name: simple-kafka
 spec:
-  version: 2.8.1
+  version: 3.1.0
   zookeeperConfigMapName: kafka-zk
   brokers:
     roleGroups:


### PR DESCRIPTION
## Description

This depends on https://github.com/stackabletech/kuttl/tree/feature/templated-tests (in particular, it corresponds to https://github.com/stackabletech/kuttl/commit/be020910b385a0e41468b691ec3894a69457e393).

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)