### PR TITLE
CI tests: set all not-tested operators to latest NIGHTLY

### DIFF
--- a/airflow-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/airflow-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     airflow-operator: "$AIRFLOW_OPERATOR_VERSION"
   nodes:
     main:

--- a/druid-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/druid-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     druid-operator: "$DRUID_OPERATOR_VERSION"
   nodes:
     main:

--- a/hbase-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/hbase-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,9 +12,8 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
-    zookeeper-operator: "0.9.0-nightly"
+    _-operator: NIGHTLY
     hbase-operator: "$HBASE_OPERATOR_VERSION"
-    hdfs-operator: "0.3.0-nightly"
   nodes:
     main:
       numberOfNodes: 3

--- a/hdfs-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/hdfs-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     hdfs-operator: "$HDFS_OPERATOR_VERSION"
   nodes:
     main:

--- a/hive-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/hive-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   location: "hel1"
   k8sVersion: "$K8S_VERSION"
   versions:
+    _-operator: NIGHTLY
     hive-operator: "$HIVE_OPERATOR_VERSION"
   nodes:
     main:

--- a/kafka-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/kafka-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     kafka-operator: "$KAFKA_OPERATOR_VERSION"
   nodes:
     main:

--- a/nifi-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/nifi-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     nifi-operator: "$NIFI_OPERATOR_VERSION"
   nodes:
     main:

--- a/opa-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/opa-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     opa-operator: "$OPA_OPERATOR_VERSION"
   nodes:
     main:

--- a/spark-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/spark-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     spark-operator: "$SPARK_OPERATOR_VERSION"
   nodes:
     main:

--- a/superset-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/superset-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     superset-operator: "$SUPERSET_OPERATOR_VERSION"
   nodes:
     main:

--- a/trino-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/trino-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,8 +12,8 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     trino-operator: "$TRINO_OPERATOR_VERSION"
-    regorule-operator: "RELEASE"
   nodes:
     main:
       numberOfNodes: 3

--- a/zookeeper-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/zookeeper-operator/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -12,6 +12,7 @@ spec:
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:
+    _-operator: NIGHTLY
     zookeeper-operator: "$ZOOKEEPER_OPERATOR_VERSION"
   nodes:
     main:


### PR DESCRIPTION
## Description
Formerly, the integration tests were run against the latest nightly version of the "operator under test" but the other (collaborating) operators were the latest release versions (T2's default). 
As we decided in the architecture meeting, the nightly integration tests should be run with all operators' nightly versions. Since this is now possible as of version `2.11.0` of T2, we changed the cluster definition files accordingly.
The HDFS integration test was run to prove that the change is effective: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/HBase%20Operator%20Integration%20Tests%20(flex)/10/

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)