### PR TITLE
Removed obsolete druid-data label on the first node of the cluster

### DIFF
--- a/create_test_cluster.py
+++ b/create_test_cluster.py
@@ -37,7 +37,7 @@ nodes:
       kind: JoinConfiguration
       nodeRegistration:
         kubeletExtraArgs:
-          node-labels: node=1,nodeType=druid-data
+          node-labels: node=1,
 - role: worker
   kubeadmConfigPatches:
     - |


### PR DESCRIPTION
## Description

This is still a left-over from the custom agent times.

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)