### PR TITLE
Update dependecy comments of renovate bot

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-actionlint@fb012b9df4b74c9ca9c45515548098a6df8169d8 # tag=v1.19.0
+      - uses: reviewdog/action-actionlint@fb012b9df4b74c9ca9c45515548098a6df8169d8 # tag=v1.21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-detect-secrets@bc7432bf205393ff7453416b3c93853773cee69d # tag=v0.8.0
+      - uses: reviewdog/action-detect-secrets@bc7432bf205393ff7453416b3c93853773cee69d # tag=v0.8.1
         with:
           github_token: ${{ secrets.github_token }}
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # renovate: tag=v2
+      - uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # renovate: tag=v3
         with:
           python-version: "3.9"
       - uses: reviewdog/action-flake8@29b3cb2cb65b42f0d6bf5597a5fe6d610f376328 # tag=v3.3.1
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-markdownlint@cde85f41b4dd6196b9997b677bbb1640f0e693c3 # renovate: tag=v0.3
+      - uses: reviewdog/action-markdownlint@cde85f41b4dd6196b9997b677bbb1640f0e693c3 # renovate: tag=v0.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -66,6 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-yamllint@21974b17ac095af86ed938bcc1eb59ce08432b97 # renovate: tag=v1.4.0
+      - uses: reviewdog/action-yamllint@21974b17ac095af86ed938bcc1eb59ce08432b97 # renovate: tag=v1.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Adopting because the 5 previous commits from dependabot did not  update the comnments. Not sure if this is the correct approach or we should either
* Use renovatebot
* Remove the comments
* something else

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)