### PR TITLE
Update Airflow version to 2.2.4-python3.9

### DIFF
--- a/airflow-operator/tests/kuttl/smoke/02-install-airflow-cluster.yaml
+++ b/airflow-operator/tests/kuttl/smoke/02-install-airflow-cluster.yaml
@@ -25,7 +25,7 @@ kind: AirflowCluster
 metadata:
   name: airflow
 spec:
-  version: 2.2.3-python3.8
+  version: 2.2.4-python3.9
   statsdExporterVersion: v0.22.4
   executor: CeleryExecutor
   loadExamples: true


### PR DESCRIPTION
## Description

Update Airflow version to 2.2.4-python3.9

Tests stackabletech/airflow-operator#55

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)