### PR TITLE
Downgrade pip package thrift to 0.13.0

### DIFF
--- a/hive-operator/tests/kuttl/smoke/requirements.txt
+++ b/hive-operator/tests/kuttl/smoke/requirements.txt
@@ -1,2 +1,2 @@
 hive-metastore-client==1.0.9
-thrift==0.15.0
+thrift==0.13.0 # Needs to match the version from hive-metastore-client


### PR DESCRIPTION
Caused problems: Cannot install -r /tmp/requirements.txt (line 1) and thrift==0.15.0 because these package versions have conflicting dependencies.

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] Changelog updated (or not applicable)