### PR TITLE
Removed node environment from custom resource

### DIFF
--- a/trino-operator/tests/kuttl/smoke/01-install-trino.yaml
+++ b/trino-operator/tests/kuttl/smoke/01-install-trino.yaml
@@ -18,7 +18,6 @@ metadata:
   name: test-trino
 spec:
   version: "0.0.362"
-  nodeEnvironment: production
   hiveConfigMapName: test-hive-derby
   authentication:
     method:


### PR DESCRIPTION
## Description

- removed node environment for https://github.com/stackabletech/trino-operator/pull/183

## Review Checklist
- [ ] Code contains useful comments
- [ ] Changelog updated (or not applicable)